### PR TITLE
Prioritize NVIDIA gpu's if multiple are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ OpenADStack is usually part of a larger deployment composition, for example with
 
     ```bash
     cd demo
+    xhost +local:
     docker compose up -d
     ```
 
@@ -44,6 +45,7 @@ OpenADStack is usually part of a larger deployment composition, for example with
 
     ```bash
     cd demo
+    xhost +local:
     export COMPOSE_PROFILES=demo-extended && docker compose up -d
     ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ OpenADStack bundles reusable OpenADServices into a Docker Compose based referenc
 > For closed-loop simulation, scenario execution, maps, and simulator adapters, [OpenADSim](https://openads-project.github.io/openadsim/openadsim.html) is the recommended entry point.
 
 > [!IMPORTANT]
-> Make sure that the general [OpenADS system requirements](https://openads-project.github.io/start/start.html#requirements) are fulfilled.
+> Make sure that the general [OpenADS system requirements](https://openads-project.github.io/start/start.html#requirements) are fulfilled. Graphical applications require access to a local X11 server.
 
 OpenADStack is usually part of a larger deployment composition, for example with the [karl. research vehicle](https://karl.ac/) or in an [OpenADSim simulation setup](https://openads-project.github.io/openadsim/openadsim.html). For a first look at OpenADStack itself, a demo is provided in this repository. It runs the stack open-loop on recorded ROS 2 data, so you can inspect the stack behavior without starting additional simulation or vehicle components.
 

--- a/utils/compose/docker-compose.template.yml
+++ b/utils/compose/docker-compose.template.yml
@@ -92,7 +92,7 @@ services:
         ;connect/endpoints=["tcp/zenoh-router:7447"]
         ;transport/shared_memory/enabled=true
         ;transport/shared_memory/transport_optimization/pool_size=100663296
-      ZENOH_ROUTER_CHECK_ATTEMPS: 0
+      ZENOH_ROUTER_CHECK_ATTEMPTS: 0
     ipc: service:zenoh-router  # overwrite with `ipc: ""` in extending service when running on machine without zenoh-router
     ulimits:
       memlock:

--- a/utils/compose/docker-compose.template.yml
+++ b/utils/compose/docker-compose.template.yml
@@ -41,6 +41,8 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
+      - __NV_PRIME_RENDER_OFFLOAD=1
+      - __GLX_VENDOR_LIBRARY_NAME=nvidia
 
   nvidia-soc-service:
     extends:
@@ -90,7 +92,7 @@ services:
         ;connect/endpoints=["tcp/zenoh-router:7447"]
         ;transport/shared_memory/enabled=true
         ;transport/shared_memory/transport_optimization/pool_size=100663296
-      ZENOH_ROUTER_CHECK_ATTEMPTS: 0
+      ZENOH_ROUTER_CHECK_ATTEMPS: 0
     ipc: service:zenoh-router  # overwrite with `ipc: ""` in extending service when running on machine without zenoh-router
     ulimits:
       memlock:
@@ -132,6 +134,8 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
+      - __NV_PRIME_RENDER_OFFLOAD=1
+      - __GLX_VENDOR_LIBRARY_NAME=nvidia
 
   ros2-nvidia-soc-service:
     extends:


### PR DESCRIPTION
- When multiple GPUs are available (for example, in a laptop), and one of them is a non-NVIDIA brand, RViz might wrongly prioritize it and not work. This change to the Docker Compose templates forces it to prioritize an NVIDIA GPU.

- Added `xhost` instructions in quick start section