### PR TITLE
Switch point_cloud_fusion to ros2-gpu-service

### DIFF
--- a/perception/point_cloud_fusion/.docker-compose.oci-overrides.yml
+++ b/perception/point_cloud_fusion/.docker-compose.oci-overrides.yml
@@ -9,7 +9,7 @@ services:
   point-cloud-fusion:
     extends:
       file: ../../utils/compose/docker-compose.template.yml
-      service: ros2-service
+      service: ros2-gpu-service
     environment:
       # --- name ------
       NAMESPACE: /perception

--- a/perception/point_cloud_fusion/docker-compose.yml
+++ b/perception/point_cloud_fusion/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   perception.point-cloud-fusion:
     extends:
       file: ../../utils/compose/docker-compose.template.yml
-      service: ros2-service
+      service: ros2-gpu-service
     image: ghcr.io/openads-project/point_cloud_fusion:v1.4.0
     environment:
       # --- name ------


### PR DESCRIPTION
Allows to run `point_cloud_fusion` on GPU.

Fixes https://github.com/openads-project/openadstack/issues/14 for now. If we want the stack to run only on CPU in the future, we should revert this change again.